### PR TITLE
Command execute function compatibility

### DIFF
--- a/lib/PHPExiftool/Tool/Command/ClassesBuilder.php
+++ b/lib/PHPExiftool/Tool/Command/ClassesBuilder.php
@@ -69,7 +69,7 @@ class ClassesBuilder extends Command
     /**
      * @see Console\Command\Command
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $start = microtime(true);
 


### PR DESCRIPTION
Error thrown on Drupal 11:

Fatal error: Declaration of PHPExiftool\Tool\Command\ClassesBuilder::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface $input, Symfony\Component\Console\Output\OutputInterface $output): int in /app/vendor/alchemy/phpexiftool/lib/PHPExiftool/Tool/Command/ClassesBuilder.php on line 72